### PR TITLE
chore: move request part of the app to a submodule

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,5 @@ jobs:
         with:
           v-version: latest
         id: v
-      - name: Build repository app
-        run: v . -shared
       - name: Run V tests
         run: v test .

--- a/request/request.v
+++ b/request/request.v
@@ -1,4 +1,4 @@
-module vachettp
+module vachettp_request
 
 pub struct Request {
 	method string

--- a/request/request_parser.v
+++ b/request/request_parser.v
@@ -1,4 +1,4 @@
-module vachettp
+module vachettp_request
 
 pub struct RequestParser {
 	command string

--- a/request/request_parser_test.v
+++ b/request/request_parser_test.v
@@ -1,4 +1,4 @@
-import vachettp
+module vachettp_request
 
 struct TestCase {
 	given string
@@ -19,7 +19,8 @@ fn test_method_parsing() {
 	]
 
 	for test_case in test_cases {
-		r := vachettp.RequestParser{test_case.given}.parse()
+		rp := RequestParser{test_case.given}
+		r := rp.parse()
 
 		assert test_case.expect == r.get_method()
 	}
@@ -38,7 +39,8 @@ fn test_protocol_version_parsing() {
 	]
 
 	for test_case in test_cases {
-		r := vachettp.RequestParser{test_case.given}.parse()
+		rp := RequestParser{test_case.given}
+		r := rp.parse()
 
 		assert test_case.expect == r.get_protocol_version()
 	}
@@ -51,7 +53,8 @@ fn test_path_parsing() {
 	]
 
 	for test_case in test_cases {
-		r := vachettp.RequestParser{test_case.given}.parse()
+		rp := RequestParser{test_case.given}
+		r := rp.parse()
 
 		assert test_case.expect == r.get_path()
 	}
@@ -59,21 +62,22 @@ fn test_path_parsing() {
 
 struct RequestTestCase {
 	given string
-	expect vachettp.Request
+	expect Request
 }
 
 fn test_command_first_line() {
 	test_cases := [
-		RequestTestCase{'', vachettp.Request{}},
-		RequestTestCase{'GET', vachettp.Request{}},
-		RequestTestCase{'GET /', vachettp.Request{}},
-		RequestTestCase{'GET HTTP/2', vachettp.Request{}},
-		RequestTestCase{'GET / HTTP/2', vachettp.Request{'GET', '/', 'HTTP/2', map[string]string{}, map[string]string{}}},
-		RequestTestCase{'GET / HTTP/2 foo', vachettp.Request{}},
+		RequestTestCase{'', Request{}},
+		RequestTestCase{'GET', Request{}},
+		RequestTestCase{'GET /', Request{}},
+		RequestTestCase{'GET HTTP/2', Request{}},
+		RequestTestCase{'GET / HTTP/2', Request{'GET', '/', 'HTTP/2', map[string]string{}, map[string]string{}}},
+		RequestTestCase{'GET / HTTP/2 foo', Request{}},
 	]
 
 	for test_case in test_cases {
-		r := vachettp.RequestParser{test_case.given}.parse()
+		rp := RequestParser{test_case.given}
+		r := rp.parse()
 
 		assert r.get_method() == test_case.expect.get_method()
 		assert r.get_path() == test_case.expect.get_path()
@@ -83,12 +87,13 @@ fn test_command_first_line() {
 
 fn test_multiline() {
 	test_cases := [
-		RequestTestCase{'GET /foo HTTP/2\r\nContent-Type: application/json', vachettp.Request{'GET', '/foo', 'HTTP/2', {'Content-Type': 'application/json'}, map[string]string{}}},
-		RequestTestCase{'GET /foo HTTP/2\r\nContent-Type: application/json\r\nAuthorization: Bearer 1337', vachettp.Request{'GET', '/foo', 'HTTP/2', {'Content-Type': 'application/json', 'Authorization': 'Bearer 1337'}, map[string]string{}}},
+		RequestTestCase{'GET /foo HTTP/2\r\nContent-Type: application/json', Request{'GET', '/foo', 'HTTP/2', {'Content-Type': 'application/json'}, map[string]string{}}},
+		RequestTestCase{'GET /foo HTTP/2\r\nContent-Type: application/json\r\nAuthorization: Bearer 1337', Request{'GET', '/foo', 'HTTP/2', {'Content-Type': 'application/json', 'Authorization': 'Bearer 1337'}, map[string]string{}}},
 	]
 
 	for test_case in test_cases {
-		r := vachettp.RequestParser{test_case.given}.parse()
+		rp := RequestParser{test_case.given}
+		r := rp.parse()
 
 		assert r.get_method() == test_case.expect.get_method()
 		assert r.get_path() == test_case.expect.get_path()
@@ -99,11 +104,11 @@ fn test_multiline() {
 
 fn test_query_params() {
 	test_cases := [
-		RequestTestCase{'GET /foo HTTP/2\r\nContent-Type: application/json', vachettp.Request{'GET', '/foo', 'HTTP/2', {'Content-Type': 'application/json'}, map[string]string{}}},
-		RequestTestCase{'GET /foo?field1=foo HTTP/2\r\nContent-Type: application/json', vachettp.Request{'GET', '/foo', 'HTTP/2', {'Content-Type': 'application/json'}, {'field1': 'foo'}}},
+		RequestTestCase{'GET /foo HTTP/2\r\nContent-Type: application/json', Request{'GET', '/foo', 'HTTP/2', {'Content-Type': 'application/json'}, map[string]string{}}},
+		RequestTestCase{'GET /foo?field1=foo HTTP/2\r\nContent-Type: application/json', Request{'GET', '/foo', 'HTTP/2', {'Content-Type': 'application/json'}, {'field1': 'foo'}}},
 		RequestTestCase{
 			'GET /foo?field1=foo&field2=bar&field3=bazz HTTP/2\r\nContent-Type: application/json', 
-			vachettp.Request{
+			Request{
 				'GET', 
 				'/foo', 
 				'HTTP/2', 
@@ -113,7 +118,7 @@ fn test_query_params() {
 		},
 		RequestTestCase{
 			'GET /foo?field1=foo&field2&field3=bazzfield4=buzz HTTP/2\r\nContent-Type: application/json', 
-			vachettp.Request{
+			Request{
 				'GET', 
 				'/foo', 
 				'HTTP/2', 
@@ -123,7 +128,7 @@ fn test_query_params() {
 		},
 		RequestTestCase{
 			'GET /foo?field1=foo&field2=barfield3=bazz HTTP/2\r\nContent-Type: application/json', 
-			vachettp.Request{
+			Request{
 				'GET', 
 				'/foo', 
 				'HTTP/2', 
@@ -134,7 +139,8 @@ fn test_query_params() {
 	]
 
 	for test_case in test_cases {
-		r := vachettp.RequestParser{test_case.given}.parse()
+		rp := RequestParser{test_case.given}
+		r := rp.parse()
 
 		assert r.get_path() == test_case.expect.get_path()
 		assert r.get_query_params() == test_case.expect.get_query_params()

--- a/request/request_test.v
+++ b/request/request_test.v
@@ -1,35 +1,35 @@
-import vachettp
+module vachettp_request
 
 fn test_get_method() {
-	rp := vachettp.RequestParser{'GET /foo HTTP/1.1'}
+	rp := RequestParser{'GET /foo HTTP/1.1'}
 	r := rp.parse()
 
 	assert r.get_method() == 'GET'
 }
 
 fn test_get_path() {
-	rp := vachettp.RequestParser{'GET /foo HTTP/1.1'}
+	rp := RequestParser{'GET /foo HTTP/1.1'}
 	r := rp.parse()
 
 	assert r.get_path() == '/foo'
 }
 
 fn test_get_protocol_version() {
-	rp := vachettp.RequestParser{'GET /foo HTTP/1.1'}
+	rp := RequestParser{'GET /foo HTTP/1.1'}
 	r := rp.parse()
 
 	assert r.get_protocol_version() == 'HTTP/1.1'
 }
 
 fn test_get_headers() {
-	rp := vachettp.RequestParser{'GET /foo HTTP/1.1\r\nContent-Type: application/json'}
+	rp := RequestParser{'GET /foo HTTP/1.1\r\nContent-Type: application/json'}
 	r := rp.parse()
 
 	assert r.get_headers() == {'Content-Type': 'application/json'}
 }
 
 fn test_get_query_params() {
-	rp := vachettp.RequestParser{'GET /foo?field1=bar&field2=bazz&field3=buzz HTTP/2\r\nContent-Type: application/json\r\nAuthorization: Bearer 1337'}
+	rp := RequestParser{'GET /foo?field1=bar&field2=bazz&field3=buzz HTTP/2\r\nContent-Type: application/json\r\nAuthorization: Bearer 1337'}
 	r := rp.parse()
 
 	assert r.get_query_params() == {'field1': 'bar', 'field2': 'bazz', 'field3': 'buzz'}


### PR DESCRIPTION
`module vachettp` references the root dir (where we will put our `server.v` file.
`module vachettp_request` has been created inside the `request` directory as a submodule.